### PR TITLE
provide feedback for connected tabs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+node_js:
+  - 14
+
+cache:
+  yarn: true
+  directories:
+    - node_modules
+
+env:
+  global:
+    - CI=test
+
+before_script:
+  - yarn install
+
+script:
+  - yarn jest

--- a/background/configuration.js
+++ b/background/configuration.js
@@ -1,6 +1,11 @@
-function saveConfiguration(config){
-	localStorage["coupling"]=config;
+function saveConfiguration(config) {
+    localStorage["coupling"] = config;
 }
-function loadConfiguration(){
-	return localStorage["coupling"];
+
+function loadConfiguration() {
+    return localStorage["coupling"];
+}
+
+function loadConfigurationAsObject() {
+    return JSON.parse(loadConfiguration())
 }

--- a/background/eventBroadcasting.js
+++ b/background/eventBroadcasting.js
@@ -26,7 +26,12 @@ function withActiveTab(f) {
 }
 
 function eachConnectedTab(activeTab, f) {
-    const coupledTabs = findCouplesForTab(activeTab, allTabs, loadConfigurationAsObject);
+    if (!coupler.hasTabCoupledTabs(activeTab.id)) {
+        return
+    }
+
+    const coupledTabs = coupler.getCoupledTabs(activeTab.id)
+
     for (let k in allTabs) {
         if (!allTabs.hasOwnProperty(k)) {
             continue;

--- a/background/eventBroadcasting.js
+++ b/background/eventBroadcasting.js
@@ -26,19 +26,17 @@ function withActiveTab(f) {
 }
 
 function eachConnectedTab(activeTab, f) {
-    const coupledTabs = findCouplesForTab(activeTab);
-    chrome.tabs.query({}, function (allTabs) {
-        for (let k in allTabs) {
-            if (!allTabs.hasOwnProperty(k)) {
-                continue;
-            }
+    const coupledTabs = findCouplesForTab(activeTab, allTabs, loadConfigurationAsObject);
+    for (let k in allTabs) {
+        if (!allTabs.hasOwnProperty(k)) {
+            continue;
+        }
 
-            const tab = allTabs[k];
-            if (tab.id !== activeTab.id) {
-                if (isTabsIdInArray(tab.id, coupledTabs)) {
-                    f(tab)
-                }
+        const tab = allTabs[k];
+        if (tab.id !== activeTab.id) {
+            if (isTabsIdInArray(tab.id, coupledTabs)) {
+                f(tab)
             }
         }
-    })
+    }
 }

--- a/background/init.js
+++ b/background/init.js
@@ -1,1 +1,29 @@
 initTabs(chrome)
+initCoupling()
+
+coupler.onDecouple = ((tabId, groupName) => {
+    try {
+        chrome.tabs.sendMessage(tabId, {
+            type: "COUPLING_STATUS_CHANGE",
+            value: "DECOUPLED",
+            groupName: groupName,
+        });
+
+    } catch (e) {
+        console.error("could not send DECOUPLED message to tab:", tabId)
+        console.error(e)
+    }
+})
+
+coupler.onCouple = ((tabId, groupName) => {
+    try {
+        chrome.tabs.sendMessage(tabId, {
+            type: "COUPLING_STATUS_CHANGE",
+            value: "COUPLED",
+            groupName: groupName,
+        });
+    } catch (e) {
+        console.error("could not send COUPLED message to tab:", tabId)
+        console.error(e)
+    }
+})

--- a/background/init.js
+++ b/background/init.js
@@ -1,0 +1,1 @@
+initTabs(chrome)

--- a/background/tabCoupling.js
+++ b/background/tabCoupling.js
@@ -118,7 +118,6 @@ function syncConfig(getConfig) {
         let group = couplings[k].group;
 
         if (config.filter((g) => g.groupName === group.groupName).length === 0) {
-            console.log("remove gropp", group)
             coupler.removeGroup(group)
         }
     }

--- a/background/tabCoupling.js
+++ b/background/tabCoupling.js
@@ -1,5 +1,5 @@
 /**
- Coupler couples tabs that match the same mirror group.
+ Coupler couples tabs with mirror groups.
  */
 const Coupler = {
     couplings: {},
@@ -98,6 +98,26 @@ function decoupleTabFromGroups(tabId) {
     }
 }
 
+function sync() {
+    coupleTabsWithGroups(allTabs, loadConfigurationAsObject)
+}
+
+function coupleTabsWithGroups(allTabs, getConfig) {
+    syncConfig(getConfig)
+
+    let couplings = coupler.getCouplings();
+    for (let k in couplings) {
+        if (!couplings.hasOwnProperty(k)) {
+            continue;
+        }
+
+        const coupling = couplings[k];
+
+        coupler.coupleTabsWithGroup(coupling.group, findCoupledTabsForTabByUrlRegExList(allTabs, coupling.group.regExList))
+    }
+}
+
+
 function syncConfig(getConfig) {
     const config = getConfig();
     for (let k in config) {
@@ -120,25 +140,6 @@ function syncConfig(getConfig) {
         if (config.filter((g) => g.groupName === group.groupName).length === 0) {
             coupler.removeGroup(group)
         }
-    }
-}
-
-function sync(){
-    coupleTabsWithGroups(allTabs,loadConfigurationAsObject)
-}
-
-function coupleTabsWithGroups(allTabs, getConfig) {
-    syncConfig(getConfig)
-
-    let couplings = coupler.getCouplings();
-    for (let k in couplings) {
-        if (!couplings.hasOwnProperty(k)) {
-            continue;
-        }
-
-        const coupling = couplings[k];
-
-        coupler.coupleTabsWithGroup(coupling.group, findCoupledTabsForTabByUrlRegExList(allTabs, coupling.group.regExList))
     }
 }
 

--- a/background/tabCoupling.js
+++ b/background/tabCoupling.js
@@ -22,7 +22,7 @@ const Coupler = {
             this.tabCouples[tab.id] = couples;
         }
     },
-    removeCouplesForTab(tab) {
+    removeCouplingForTab(tab) {
         delete this.tabCouples[tab.id];
     },
     isTabBlockedFromDetection(tab) {
@@ -38,7 +38,7 @@ const Coupler = {
 
 const coupler = Object.create(Coupler)
 
-function refreshCouplesForTabAndItsCouples(tab) {
+function removeCouplesForTabAndItsCouples(tab) {
     if (coupler.hasTabCoupledTabs(tab)) {
         const couples = coupler.getCouples(tab);
         for (let k in couples) {
@@ -47,10 +47,10 @@ function refreshCouplesForTabAndItsCouples(tab) {
             }
 
             const coupledTabId = couples[k];
-            coupler.removeCouplesForTab({id: coupledTabId});
+            coupler.removeCouplingForTab({id: coupledTabId});
         }
     }
-    coupler.removeCouplesForTab(tab);
+    coupler.removeCouplingForTab(tab);
 }
 
 function findCouplesForTab(tab, allTabs, getConfig) {

--- a/background/tabCoupling.js
+++ b/background/tabCoupling.js
@@ -47,8 +47,8 @@ const Coupler = {
                 continue;
             }
 
-            const tab = g.tabs[k]
-            this.onDecouple(tab.id, g.groupName)
+            const tabId = g.tabs[k]
+            this.onDecouple(tabId, g.groupName)
         }
 
         delete this.couplings[group.groupName]
@@ -115,12 +115,17 @@ function syncConfig(getConfig) {
             continue;
         }
 
-        let group = couplings[k];
+        let group = couplings[k].group;
 
         if (config.filter((g) => g.groupName === group.groupName).length === 0) {
+            console.log("remove gropp", group)
             coupler.removeGroup(group)
         }
     }
+}
+
+function sync(){
+    coupleTabsWithGroups(allTabs,loadConfigurationAsObject)
 }
 
 function coupleTabsWithGroups(allTabs, getConfig) {

--- a/background/tabCoupling.js
+++ b/background/tabCoupling.js
@@ -3,23 +3,31 @@
  */
 const Coupler = {
     tabCouples: [],
+    onDecouple: (tabId) => {
+    },
+    onCouple: (tabId) => {
+    },
     hasTabCoupledTabs: function (tab) {
-        return (typeof this.tabCouples[tab.id] !== "undefined");
+        return (typeof this.tabCouples[tab.id] !== "undefined" && this.tabCouples[tab.id]  !== 0);
     },
     addCouplesForTab(tab, couples) {
         if (typeof this.tabCouples[tab.id] !== "undefined") {
             if (coupler.isTabBlockedFromDetection(tab)) {
                 this.tabCouples[tab.id] = [];
             }
-            for (let k in couples) {
-                if (!couples.hasOwnProperty(k)) {
-                    continue;
-                }
-
-                this.tabCouples[tab.id][k] = couples[k];
-            }
         } else {
-            this.tabCouples[tab.id] = couples;
+            this.onCouple(tab.id);
+            this.tabCouples[tab.id] = [];
+        }
+
+        for (let k in couples) {
+            if (!couples.hasOwnProperty(k)) {
+                continue;
+            }
+
+            let tabId = couples[k];
+            this.tabCouples[tab.id][k] = tabId;
+            this.onCouple(tabId);
         }
     },
     removeCouplingForTab(tab) {
@@ -33,24 +41,29 @@ const Coupler = {
     },
     getCouples(tab) {
         return this.tabCouples[tab.id];
+    },
+    cleanCouplings(tab) {
+        if (this.hasTabCoupledTabs(tab)) {
+            const couples = this.getCouples(tab);
+            for (let k in couples) {
+                if (!couples.hasOwnProperty(k)) {
+                    continue;
+                }
+
+                const coupledTabId = couples[k];
+                this.removeCouplingForTab({id: coupledTabId});
+                this.onDecouple(coupledTabId)
+            }
+        }
+        this.removeCouplingForTab(tab);
+        this.onDecouple(tab.id)
     }
 };
 
 const coupler = Object.create(Coupler)
 
 function removeCouplesForTabAndItsCouples(tab) {
-    if (coupler.hasTabCoupledTabs(tab)) {
-        const couples = coupler.getCouples(tab);
-        for (let k in couples) {
-            if (!couples.hasOwnProperty(k)) {
-                continue;
-            }
-
-            const coupledTabId = couples[k];
-            coupler.removeCouplingForTab({id: coupledTabId});
-        }
-    }
-    coupler.removeCouplingForTab(tab);
+    coupler.cleanCouplings(tab)
 }
 
 function findCouplesForTab(tab, allTabs, getConfig) {

--- a/background/tabCoupling.js
+++ b/background/tabCoupling.js
@@ -117,7 +117,6 @@ function coupleTabsWithGroups(allTabs, getConfig) {
     }
 }
 
-
 function syncConfig(getConfig) {
     const config = getConfig();
     for (let k in config) {

--- a/background/tabCoupling.test.js
+++ b/background/tabCoupling.test.js
@@ -1,98 +1,115 @@
 const rewire = require('rewire');
-const code = rewire('./tabCoupling.js');
+const sinon = require('sinon');
+let coupler = null;
+let findCouplesForTab = null;
 
-test('add/remove coupled tabs', () => {
-    const coupler = code.__get__('coupler');
+describe("tab couplings", () => {
+    beforeEach(() => {
+        const code = rewire('./tabCoupling.js');
+        coupler = code.__get__('coupler');
+        findCouplesForTab = code.__get__('findCouplesForTab');
+    })
+    test('add/remove coupled tabs', () => {
+        const tabId = "1";
+        const tab = {id: tabId};
+        const couples = ["a", "b"];
 
-    const tabId = "1";
-    const tab = {id: tabId};
-    const couples = [{id: "a"}, {id: "b"}];
+        coupler.removeCouplingForTab(tab)
+        expect(coupler.tabCouples).toHaveLength(0);
+        expect(coupler.hasTabCoupledTabs(tab)).toBeFalsy();
 
-    coupler.removeCouplesForTab(tab)
-    expect(coupler.tabCouples).toHaveLength(0);
-    expect(coupler.hasTabCoupledTabs(tab)).toBeFalsy();
+        coupler.addCouplesForTab(tab, couples);
+        expect(coupler.tabCouples[tabId]).toEqual(couples);
+        expect(coupler.hasTabCoupledTabs(tab)).toBeTruthy();
+    });
 
-    coupler.addCouplesForTab(tab, couples);
-    expect(coupler.tabCouples[tabId]).toEqual(couples);
-    expect(coupler.hasTabCoupledTabs(tab)).toBeTruthy();
-});
+    test('add/remove coupled tabs - callbacks are called', () => {
+        coupler.onCouple = sinon.spy();
+        coupler.onDecouple = sinon.spy();
 
-test('tab is blocked from detection', () => {
-    const coupler = code.__get__('coupler');
+        const tabId = "1";
+        const tab = {id: tabId};
+        const couples = ["a", "b"];
 
-    const tabId = "1";
-    const tab = {id: tabId};
+        coupler.addCouplesForTab(tab, couples);
+        expect(coupler.onCouple.callCount).toEqual(3)
+        expect(coupler.onCouple.args[0][0]).toEqual(tabId)
+        expect(coupler.onCouple.args[1][0]).toEqual(couples[0])
+        expect(coupler.onCouple.args[2][0]).toEqual(couples[1])
 
-    expect(coupler.isTabBlockedFromDetection(tab)).toBeFalsy();
-    coupler.blockTabFromDetection(tab)
-    expect(coupler.isTabBlockedFromDetection(tab)).toBeTruthy();
-});
+        coupler.cleanCouplings(tab)
+        expect(coupler.onDecouple.callCount).toEqual(3)
+        expect(coupler.onDecouple.args[0][0]).toEqual(couples[0])
+    });
 
-test('findCouplesForTab with no configuration returns null', () => {
-    const findCouplesForTab = code.__get__('findCouplesForTab');
-    const coupler = code.__get__('coupler');
+    test('tab is blocked from detection', () => {
+        const tabId = "1";
+        const tab = {id: tabId};
 
-    const loadConfiguration = function () {
-        return {};
-    }
-    const tabId = "1";
-    const tab = {id: tabId, url: "http://test.com"};
+        expect(coupler.isTabBlockedFromDetection(tab)).toBeFalsy();
+        coupler.blockTabFromDetection(tab)
+        expect(coupler.isTabBlockedFromDetection(tab)).toBeTruthy();
+    });
 
-    coupler.blockTabFromDetection(tab);
+    test('findCouplesForTab with no configuration returns null', () => {
+        const loadConfiguration = function () {
+            return {};
+        }
+        const allTabs = [];
+        const tabId = "1";
+        const tab = {id: tabId, url: ""};
 
-    expect(findCouplesForTab(tab, loadConfiguration)).toHaveLength(0);
-});
+        expect(findCouplesForTab(tab, allTabs, loadConfiguration)).toHaveLength(0);
+    });
 
-test('findCouplesForTab for tab that is blocked from detection will return empty array', () => {
-    const findCouplesForTab = code.__get__('findCouplesForTab');
+    test('findCouplesForTab for tab that is blocked from detection will return empty array', () => {
+        const loadConfiguration = function () {
+            return {};
+        }
+        const allTabs = [];
+        const tabId = "1";
+        const tab = {id: tabId, url: ""};
 
-    const loadConfiguration = function () {
-        return {};
-    }
-    const tabId = "1";
-    const tab = {id: tabId, url: "http://test.com"};
+        coupler.blockTabFromDetection(tab);
 
-    expect(findCouplesForTab(tab, loadConfiguration)).toHaveLength(0);
-});
+        expect(findCouplesForTab(tab, allTabs, loadConfiguration)).toHaveLength(0);
+    });
 
-test('findCouplesForTab if couples already have been set, they are returned ', () => {
-    const findCouplesForTab = code.__get__('findCouplesForTab');
-    const coupler = code.__get__('coupler');
+    test('findCouplesForTab if couples already have been set, they are returned ', () => {
+        const loadConfiguration = function () {
+            return {};
+        }
+        const allTabs = [];
+        const tabId = "1";
+        const tab = {id: tabId, url: ""};
+        const couples = ["a", "b"];
 
-    const loadConfiguration = function () {
-        return {};
-    }
-    const tabId = "1";
-    const tab = {id: tabId, url: "http://test.com"};
-    const couples = [{id: "a"}, {id: "b"}];
+        coupler.addCouplesForTab(tab, couples)
 
-    coupler.addCouplesForTab(tab, couples)
+        expect(findCouplesForTab(tab, allTabs, loadConfiguration)).toEqual(couples);
+    });
 
-    expect(findCouplesForTab(tab, loadConfiguration)).toEqual(couples);
-});
+    test('findCouplesForTab couples are found by matching mirror group configs against all tabs', () => {
+        const loadConfiguration = function () {
+            return [
+                {
+                    "regExList": [
+                        {"regEx": "www.github.com"}
+                    ],
+                    "groupName": "test-group"
+                }
+            ]
+        };
+        const tabId = "a";
+        const tab = {id: tabId, url: "http://www.github.com"};
+        const allTabs = [
+            {id: "b", url: "http://www.gitlab.com"},
+            {id: "c", url: "https://www.github.com/Oppodelldog/chrome-extension-mirror"},
+        ];
 
-test('findCouplesForTab couples are found by matching mirror group configs against all tabs', () => {
-    const findCouplesForTab = code.__get__('findCouplesForTab');
+        // tab "a" and "c" match the regEx pattern from config "test-group"
+        const expectedId = allTabs[1].id;
 
-    const loadConfiguration = function () {
-        return [
-            {
-                "regExList": [
-                    {"regEx": "www.github.com"}
-                ],
-                "groupName": "test-group"
-            }
-        ]
-    };
-    const tabId = "a";
-    const tab = {id: tabId, url: "http://www.github.com"};
-    const allTabs = [
-        {id: "b", url: "http://www.gitlab.com"},
-        {id: "c", url: "https://www.github.com/Oppodelldog/chrome-extension-mirror"},
-    ];
-
-    // tab "a" and "c" match the regEx pattern from config "test-group"
-    const expectedId = allTabs[1].id;
-
-    expect(findCouplesForTab(tab, allTabs, loadConfiguration)).toEqual([expectedId]);
-});
+        expect(findCouplesForTab(tab, allTabs, loadConfiguration)).toEqual([expectedId]);
+    })
+})

--- a/background/tabCoupling.test.js
+++ b/background/tabCoupling.test.js
@@ -1,12 +1,13 @@
 const rewire = require('rewire');
 const sinon = require('sinon');
+let code = null;
 let coupler = null;
 
 describe("tab couplings", () => {
     beforeEach(() => {
-        const code = rewire('./tabCoupling.js');
+        code = rewire('./tabCoupling.js');
         initCoupling = code.__get__('initCoupling');
-        coupleTabsWithGroups = code.__get__('coupleTabsWithGroups');
+        sync = code.__get__('sync');
 
         initCoupling();
         coupler = code.__get__('coupler');
@@ -15,7 +16,7 @@ describe("tab couplings", () => {
     })
 
     test('coupleTabsWithGroups', () => {
-        const loadConfiguration = function () {
+        const loadConfigurationAsObject = function () {
             return [
                 {
                     "regExList": [
@@ -30,7 +31,9 @@ describe("tab couplings", () => {
         let tab3 = {id: "c", url: "https://www.github.com/Oppodelldog/chrome-extension-mirror"};
         const allTabs = [tab1, tab2, tab3];
 
-        coupleTabsWithGroups(allTabs, loadConfiguration);
+        code.__set__("allTabs", allTabs)
+        code.__set__("loadConfigurationAsObject", loadConfigurationAsObject)
+        sync();
 
         const expectedCouplings = {
             'test-group': {
@@ -40,7 +43,7 @@ describe("tab couplings", () => {
         };
 
         expect(coupler.couplings).toEqual(expectedCouplings);
-        
+
         expect(coupler.onCouple.callCount).toEqual(2);
         expect(coupler.onCouple.args[0][0]).toEqual("1");
         expect(coupler.onCouple.args[1][0]).toEqual("c");

--- a/background/tabCoupling.test.js
+++ b/background/tabCoupling.test.js
@@ -1,0 +1,102 @@
+const rewire = require('rewire');
+loadConfiguration = function () {
+    return "HELLO"
+};
+
+const code = rewire('./tabCoupling.js');
+
+test('add/remove coupled tabs', () => {
+    const coupler = code.__get__('coupler');
+
+    const tabId = "1";
+    const tab = {id: tabId};
+    const couples = [{id: "a"}, {id: "b"}];
+
+    coupler.removeCouplesForTab(tab)
+    expect(coupler.tabCouples).toHaveLength(0);
+    expect(coupler.hasTabCoupledTabs(tab)).toBeFalsy();
+
+    coupler.addCouplesForTab(tab, couples);
+    expect(coupler.tabCouples[tabId]).toEqual(couples);
+    expect(coupler.hasTabCoupledTabs(tab)).toBeTruthy();
+});
+
+test('tab is blocked from detection', () => {
+    const coupler = code.__get__('coupler');
+
+    const tabId = "1";
+    const tab = {id: tabId};
+
+    expect(coupler.isTabBlockedFromDetection(tab)).toBeFalsy();
+    coupler.blockTabFromDetection(tab)
+    expect(coupler.isTabBlockedFromDetection(tab)).toBeTruthy();
+});
+
+test('findCouplesForTab with no configuration returns null', () => {
+    const findCouplesForTab = code.__get__('findCouplesForTab');
+    const coupler = code.__get__('coupler');
+
+    const loadConfiguration = function () {
+        return {};
+    }
+    const tabId = "1";
+    const tab = {id: tabId, url: "http://test.com"};
+
+    coupler.blockTabFromDetection(tab);
+
+    expect(findCouplesForTab(tab, loadConfiguration)).toHaveLength(0);
+});
+
+test('findCouplesForTab for tab that is blocked from detection will return empty array', () => {
+    const findCouplesForTab = code.__get__('findCouplesForTab');
+
+    const loadConfiguration = function () {
+        return {};
+    }
+    const tabId = "1";
+    const tab = {id: tabId, url: "http://test.com"};
+
+    expect(findCouplesForTab(tab, loadConfiguration)).toHaveLength(0);
+});
+
+test('findCouplesForTab if couples already have been set, they are returned ', () => {
+    const findCouplesForTab = code.__get__('findCouplesForTab');
+    const coupler = code.__get__('coupler');
+
+    const loadConfiguration = function () {
+        return {};
+    }
+    const tabId = "1";
+    const tab = {id: tabId, url: "http://test.com"};
+    const couples = [{id: "a"}, {id: "b"}];
+
+    coupler.addCouplesForTab(tab, couples)
+
+    expect(findCouplesForTab(tab, loadConfiguration)).toEqual(couples);
+});
+
+test('findCouplesForTab couples are found by matching mirror group configs against all tabs', () => {
+    const findCouplesForTab = code.__get__('findCouplesForTab');
+
+    const loadConfiguration = function () {
+        return [
+            {
+                "regExList": [
+                    {"regEx": "www.github.com"}
+                ],
+                "groupName": "test-group"
+            }
+        ]
+    };
+    const tabId = "a";
+    const tab = {id: tabId, url: "http://www.github.com"};
+    const allTabs = [
+        {id: "b", url: "http://www.gitlab.com"},
+        {id: "c", url: "https://www.github.com/Oppodelldog/chrome-extension-mirror"},
+    ];
+
+    // tab "a" and "c" match the regEx pattern from config "test-group"
+    const expectedId = allTabs[1].id;
+
+    expect(findCouplesForTab(tab, allTabs, loadConfiguration)).toEqual([expectedId]);
+});

--- a/background/tabCoupling.test.js
+++ b/background/tabCoupling.test.js
@@ -1,8 +1,4 @@
 const rewire = require('rewire');
-loadConfiguration = function () {
-    return "HELLO"
-};
-
 const code = rewire('./tabCoupling.js');
 
 test('add/remove coupled tabs', () => {

--- a/background/tabCoupling.test.js
+++ b/background/tabCoupling.test.js
@@ -2,6 +2,7 @@ const rewire = require('rewire');
 const sinon = require('sinon');
 let code = null;
 let coupler = null;
+let sync = null;
 
 describe("tab couplings", () => {
     beforeEach(() => {

--- a/background/tabCoupling.test.js
+++ b/background/tabCoupling.test.js
@@ -1,95 +1,20 @@
 const rewire = require('rewire');
 const sinon = require('sinon');
 let coupler = null;
-let findCouplesForTab = null;
 
 describe("tab couplings", () => {
     beforeEach(() => {
         const code = rewire('./tabCoupling.js');
+        initCoupling = code.__get__('initCoupling');
+        coupleTabsWithGroups = code.__get__('coupleTabsWithGroups');
+
+        initCoupling();
         coupler = code.__get__('coupler');
-        findCouplesForTab = code.__get__('findCouplesForTab');
-    })
-    test('add/remove coupled tabs', () => {
-        const tabId = "1";
-        const tab = {id: tabId};
-        const couples = ["a", "b"];
-
-        coupler.removeCouplingForTab(tab)
-        expect(coupler.tabCouples).toHaveLength(0);
-        expect(coupler.hasTabCoupledTabs(tab)).toBeFalsy();
-
-        coupler.addCouplesForTab(tab, couples);
-        expect(coupler.tabCouples[tabId]).toEqual(couples);
-        expect(coupler.hasTabCoupledTabs(tab)).toBeTruthy();
-    });
-
-    test('add/remove coupled tabs - callbacks are called', () => {
         coupler.onCouple = sinon.spy();
         coupler.onDecouple = sinon.spy();
+    })
 
-        const tabId = "1";
-        const tab = {id: tabId};
-        const couples = ["a", "b"];
-
-        coupler.addCouplesForTab(tab, couples);
-        expect(coupler.onCouple.callCount).toEqual(3)
-        expect(coupler.onCouple.args[0][0]).toEqual(tabId)
-        expect(coupler.onCouple.args[1][0]).toEqual(couples[0])
-        expect(coupler.onCouple.args[2][0]).toEqual(couples[1])
-
-        coupler.cleanCouplings(tab)
-        expect(coupler.onDecouple.callCount).toEqual(3)
-        expect(coupler.onDecouple.args[0][0]).toEqual(couples[0])
-    });
-
-    test('tab is blocked from detection', () => {
-        const tabId = "1";
-        const tab = {id: tabId};
-
-        expect(coupler.isTabBlockedFromDetection(tab)).toBeFalsy();
-        coupler.blockTabFromDetection(tab)
-        expect(coupler.isTabBlockedFromDetection(tab)).toBeTruthy();
-    });
-
-    test('findCouplesForTab with no configuration returns null', () => {
-        const loadConfiguration = function () {
-            return {};
-        }
-        const allTabs = [];
-        const tabId = "1";
-        const tab = {id: tabId, url: ""};
-
-        expect(findCouplesForTab(tab, allTabs, loadConfiguration)).toHaveLength(0);
-    });
-
-    test('findCouplesForTab for tab that is blocked from detection will return empty array', () => {
-        const loadConfiguration = function () {
-            return {};
-        }
-        const allTabs = [];
-        const tabId = "1";
-        const tab = {id: tabId, url: ""};
-
-        coupler.blockTabFromDetection(tab);
-
-        expect(findCouplesForTab(tab, allTabs, loadConfiguration)).toHaveLength(0);
-    });
-
-    test('findCouplesForTab if couples already have been set, they are returned ', () => {
-        const loadConfiguration = function () {
-            return {};
-        }
-        const allTabs = [];
-        const tabId = "1";
-        const tab = {id: tabId, url: ""};
-        const couples = ["a", "b"];
-
-        coupler.addCouplesForTab(tab, couples)
-
-        expect(findCouplesForTab(tab, allTabs, loadConfiguration)).toEqual(couples);
-    });
-
-    test('findCouplesForTab couples are found by matching mirror group configs against all tabs', () => {
+    test('coupleTabsWithGroups', () => {
         const loadConfiguration = function () {
             return [
                 {
@@ -100,16 +25,24 @@ describe("tab couplings", () => {
                 }
             ]
         };
-        const tabId = "a";
-        const tab = {id: tabId, url: "http://www.github.com"};
-        const allTabs = [
-            {id: "b", url: "http://www.gitlab.com"},
-            {id: "c", url: "https://www.github.com/Oppodelldog/chrome-extension-mirror"},
-        ];
+        let tab1 = {id: "1", url: "http://www.github.com"};
+        let tab2 = {id: "b", url: "http://www.gitlab.com"};
+        let tab3 = {id: "c", url: "https://www.github.com/Oppodelldog/chrome-extension-mirror"};
+        const allTabs = [tab1, tab2, tab3];
 
-        // tab "a" and "c" match the regEx pattern from config "test-group"
-        const expectedId = allTabs[1].id;
+        coupleTabsWithGroups(allTabs, loadConfiguration);
 
-        expect(findCouplesForTab(tab, allTabs, loadConfiguration)).toEqual([expectedId]);
+        const expectedCouplings = {
+            'test-group': {
+                group: {regExList: [{"regEx": "www.github.com"}], groupName: 'test-group'},
+                tabs: ['1', 'c']
+            }
+        };
+
+        expect(coupler.couplings).toEqual(expectedCouplings);
+        
+        expect(coupler.onCouple.callCount).toEqual(2);
+        expect(coupler.onCouple.args[0][0]).toEqual("1");
+        expect(coupler.onCouple.args[1][0]).toEqual("c");
     })
 })

--- a/background/tabs.js
+++ b/background/tabs.js
@@ -7,28 +7,42 @@ let allTabs = [];
 
 function addTab(tab) {
     allTabs[tab.id] = tab;
+
+    coupleTabsWithGroups(allTabs, loadConfigurationAsObject);
 }
 
-function delTab(tab) {
-    delete allTabs[tab.id];
+function delTab(tabId) {
+    delete allTabs[tabId];
+    decoupleTabFromGroups(tabId)
 }
 
-function initTabs(chrome) {
+function addOnTabUpdatedListener(chrome) {
     chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
-        addTab(tab);
         if (changeInfo.status === "complete") {
-            removeCouplesForTabAndItsCouples(tab);
+            addTab(tab);
         }
     });
+}
 
+function addOnTabActivatedListener(chrome) {
     chrome.tabs.onActivated.addListener(function (evt) {
         chrome.tabs.get(evt.tabId, function (tab) {
             addTab(tab);
-            removeCouplesForTabAndItsCouples(tab);
         });
     });
+}
 
-
-    chrome.tabs.onCreated.addListener(addTab);
+function addOnTabRemovedListener(chrome) {
     chrome.tabs.onRemoved.addListener(delTab);
+}
+
+function addOnTabCreatedListener(chrome) {
+    chrome.tabs.onCreated.addListener(addTab);
+}
+
+function initTabs(chrome) {
+    addOnTabUpdatedListener(chrome);
+    addOnTabActivatedListener(chrome);
+    addOnTabCreatedListener(chrome);
+    addOnTabRemovedListener(chrome);
 }

--- a/background/tabs.js
+++ b/background/tabs.js
@@ -1,0 +1,32 @@
+/*
+    This keeps track of all chrome tabs.
+    Having an array of all tabs is easy to work with in comparison to
+    do a chrome async query and do work in its callback.
+ */
+let allTabs = [];
+
+function addTab(tab) {
+    allTabs[tab.id] = tab;
+}
+
+function delTab(tab) {
+    delete allTabs[tab.id];
+}
+
+window.chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+    addTab(tab);
+    if (changeInfo.status === "complete") {
+        refreshCouplesForTabAndItsCouples(tab);
+    }
+});
+
+window.chrome.tabs.onActivated.addListener(function (evt) {
+    chrome.tabs.get(evt.tabId, function (tab) {
+        addTab(tab);
+        refreshCouplesForTabAndItsCouples(tab);
+    });
+});
+
+
+window.chrome.tabs.onCreated.addListener(addTab);
+window.chrome.tabs.onRemoved.addListener(delTab);

--- a/background/tabs.js
+++ b/background/tabs.js
@@ -17,14 +17,14 @@ function initTabs(chrome) {
     chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
         addTab(tab);
         if (changeInfo.status === "complete") {
-            refreshCouplesForTabAndItsCouples(tab);
+            removeCouplesForTabAndItsCouples(tab);
         }
     });
 
     chrome.tabs.onActivated.addListener(function (evt) {
         chrome.tabs.get(evt.tabId, function (tab) {
             addTab(tab);
-            refreshCouplesForTabAndItsCouples(tab);
+            removeCouplesForTabAndItsCouples(tab);
         });
     });
 

--- a/background/tabs.js
+++ b/background/tabs.js
@@ -8,7 +8,7 @@ let allTabs = [];
 function addTab(tab) {
     allTabs[tab.id] = tab;
 
-    coupleTabsWithGroups(allTabs, loadConfigurationAsObject);
+    sync();
 }
 
 function delTab(tabId) {

--- a/background/tabs.js
+++ b/background/tabs.js
@@ -13,20 +13,22 @@ function delTab(tab) {
     delete allTabs[tab.id];
 }
 
-window.chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
-    addTab(tab);
-    if (changeInfo.status === "complete") {
-        refreshCouplesForTabAndItsCouples(tab);
-    }
-});
-
-window.chrome.tabs.onActivated.addListener(function (evt) {
-    chrome.tabs.get(evt.tabId, function (tab) {
+function initTabs(chrome) {
+    chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
         addTab(tab);
-        refreshCouplesForTabAndItsCouples(tab);
+        if (changeInfo.status === "complete") {
+            refreshCouplesForTabAndItsCouples(tab);
+        }
     });
-});
+
+    chrome.tabs.onActivated.addListener(function (evt) {
+        chrome.tabs.get(evt.tabId, function (tab) {
+            addTab(tab);
+            refreshCouplesForTabAndItsCouples(tab);
+        });
+    });
 
 
-window.chrome.tabs.onCreated.addListener(addTab);
-window.chrome.tabs.onRemoved.addListener(delTab);
+    chrome.tabs.onCreated.addListener(addTab);
+    chrome.tabs.onRemoved.addListener(delTab);
+}

--- a/background/tabs.test.js
+++ b/background/tabs.test.js
@@ -1,0 +1,108 @@
+const chrome = require("sinon-chrome");
+const sinon = require("sinon")
+const rewire = require('rewire');
+let code = null;
+
+describe("tabs", () => {
+    beforeEach(() => {
+        chrome.flush();
+        code = rewire('./tabs.js');
+    })
+
+    test('initTabs', () => {
+        const initTabs = code.__get__('initTabs');
+
+        initTabs(chrome)
+
+        expect(chrome.tabs.onUpdated.addListener.calledOnce).toBeTruthy();
+        expect(chrome.tabs.onActivated.addListener.calledOnce).toBeTruthy();
+        expect(chrome.tabs.onCreated.addListener.calledOnce).toBeTruthy();
+        expect(chrome.tabs.onRemoved.addListener.calledOnce).toBeTruthy();
+    });
+
+    test('tab onUpdated - adds tab', () => {
+        const initTabs = code.__get__('initTabs');
+        const allTabs = code.__get__('allTabs');
+
+        let tabStub = {id: 1};
+
+        initTabs(chrome)
+
+        // noinspection JSUnresolvedFunction
+        chrome.tabs.onUpdated.dispatch(1, {}, tabStub)
+
+        expect(allTabs[tabStub.id]).toStrictEqual(tabStub);
+    });
+
+    test('tab onUpdated - with stauts "complete" it calls refreshCouplesForTabAndItsCouples', () => {
+        const initTabs = code.__get__('initTabs');
+
+        let tabStub = {id: 1};
+        let refreshSpy = sinon.spy()
+        code.__set__('refreshCouplesForTabAndItsCouples', refreshSpy)
+
+        initTabs(chrome)
+
+        // noinspection JSUnresolvedFunction
+        chrome.tabs.onUpdated.dispatch(1, {status: "complete"}, tabStub)
+
+        expect(refreshSpy.calledOnce).toBeTruthy()
+    });
+
+    test('tab onActivated - resolves tab, adds it and calls refreshCouplesForTabAndItsCouples', () => {
+        const initTabs = code.__get__('initTabs');
+        const allTabs = code.__get__('allTabs');
+
+        let tabActiveInfo = {tabId: 1}
+
+        initTabs(chrome)
+
+        // noinspection JSUnresolvedFunction
+        chrome.tabs.onActivated.dispatch(tabActiveInfo)
+
+        expect(chrome.tabs.get.calledOnce).toBeTruthy()
+        expect(chrome.tabs.get.args[0][0]).toEqual(tabActiveInfo.tabId)
+
+        let tabStub = {id: 2};
+        let refreshSpy = sinon.spy()
+        code.__set__('refreshCouplesForTabAndItsCouples', refreshSpy)
+
+        chrome.tabs.get.args[0][1](tabStub)
+
+        expect(allTabs[tabStub.id]).toStrictEqual(tabStub);
+        expect(refreshSpy.calledOnce).toBeTruthy()
+        expect(refreshSpy.args[0][0]).toEqual(tabStub)
+    })
+
+    test('tab onCreated - adds tab', () => {
+        const initTabs = code.__get__('initTabs');
+        const allTabs = code.__get__('allTabs');
+
+        let tabStub = {id: 1};
+
+        initTabs(chrome)
+
+        // noinspection JSUnresolvedFunction
+        chrome.tabs.onCreated.dispatch(1, {}, tabStub)
+
+        expect(allTabs[tabStub.id]).toStrictEqual(tabStub);
+    })
+
+    test('tab onRemoved - removes tab', () => {
+        const initTabs = code.__get__('initTabs');
+        const allTabs = code.__get__('allTabs');
+
+        let tabStub = {id: 1};
+        allTabs[1] = tabStub;
+
+        initTabs(chrome)
+
+        expect(allTabs[tabStub.id]).toStrictEqual(tabStub);
+
+        // noinspection JSUnresolvedFunction
+        chrome.tabs.onRemoved.dispatch(1, {}, tabStub)
+
+        expect(allTabs[tabStub.id]).toBeUndefined();
+    })
+
+})

--- a/background/tabs.test.js
+++ b/background/tabs.test.js
@@ -83,7 +83,7 @@ describe("tabs", () => {
         initTabs(chrome)
 
         // noinspection JSUnresolvedFunction
-        chrome.tabs.onCreated.dispatch(1, {}, tabStub)
+        chrome.tabs.onCreated.dispatch(tabStub)
 
         expect(allTabs[tabStub.id]).toStrictEqual(tabStub);
     })
@@ -100,7 +100,7 @@ describe("tabs", () => {
         expect(allTabs[tabStub.id]).toStrictEqual(tabStub);
 
         // noinspection JSUnresolvedFunction
-        chrome.tabs.onRemoved.dispatch(1, {}, tabStub)
+        chrome.tabs.onRemoved.dispatch(tabStub)
 
         expect(allTabs[tabStub.id]).toBeUndefined();
     })

--- a/background/tabs.test.js
+++ b/background/tabs.test.js
@@ -14,12 +14,11 @@ describe("tabs", () => {
         allTabs = moduleUnderTest.__get__('allTabs');
         removeCouplesForTabAndItsCouples = sinon.spy()
         moduleUnderTest.__set__('removeCouplesForTabAndItsCouples', removeCouplesForTabAndItsCouples)
+
+        initTabs(chrome)
     })
 
     test('initTabs', () => {
-
-        initTabs(chrome)
-
         expect(chrome.tabs.onUpdated.addListener.calledOnce).toBeTruthy();
         expect(chrome.tabs.onActivated.addListener.calledOnce).toBeTruthy();
         expect(chrome.tabs.onCreated.addListener.calledOnce).toBeTruthy();
@@ -28,8 +27,6 @@ describe("tabs", () => {
 
     test('tab onUpdated - adds tab', () => {
         let tabStub = {id: 1};
-
-        initTabs(chrome)
 
         // noinspection JSUnresolvedFunction
         chrome.tabs.onUpdated.dispatch(1, {}, tabStub)
@@ -40,8 +37,6 @@ describe("tabs", () => {
     test('tab onUpdated - with status "complete" it calls removeCouplesForTabAndItsCouples', () => {
         let tabStub = {id: 1};
 
-        initTabs(chrome)
-
         // noinspection JSUnresolvedFunction
         chrome.tabs.onUpdated.dispatch(1, {status: "complete"}, tabStub)
 
@@ -51,8 +46,6 @@ describe("tabs", () => {
 
     test('tab onActivated - resolves tab, adds it and calls removeCouplesForTabAndItsCouples', () => {
         let tabActiveInfo = {tabId: 1}
-
-        initTabs(chrome)
 
         // noinspection JSUnresolvedFunction
         chrome.tabs.onActivated.dispatch(tabActiveInfo)
@@ -72,8 +65,6 @@ describe("tabs", () => {
     test('tab onCreated - adds tab', () => {
         let tabStub = {id: 1};
 
-        initTabs(chrome)
-
         // noinspection JSUnresolvedFunction
         chrome.tabs.onCreated.dispatch(tabStub)
 
@@ -81,13 +72,8 @@ describe("tabs", () => {
     })
 
     test('tab onRemoved - removes tab', () => {
-        const initTabs = moduleUnderTest.__get__('initTabs');
-        const allTabs = moduleUnderTest.__get__('allTabs');
-
         let tabStub = {id: 1};
         allTabs[1] = tabStub;
-
-        initTabs(chrome)
 
         expect(allTabs[tabStub.id]).toStrictEqual(tabStub);
 

--- a/background/tabs.test.js
+++ b/background/tabs.test.js
@@ -4,7 +4,7 @@ const rewire = require('rewire');
 let moduleUnderTest = null;
 let initTabs = null;
 let allTabs = null;
-let refreshCouplesForTabAndItsCouples = null;
+let removeCouplesForTabAndItsCouples = null;
 
 describe("tabs", () => {
     beforeEach(() => {
@@ -12,8 +12,8 @@ describe("tabs", () => {
         moduleUnderTest = rewire('./tabs.js');
         initTabs = moduleUnderTest.__get__('initTabs');
         allTabs = moduleUnderTest.__get__('allTabs');
-        refreshCouplesForTabAndItsCouples = sinon.spy()
-        moduleUnderTest.__set__('refreshCouplesForTabAndItsCouples', refreshCouplesForTabAndItsCouples)
+        removeCouplesForTabAndItsCouples = sinon.spy()
+        moduleUnderTest.__set__('removeCouplesForTabAndItsCouples', removeCouplesForTabAndItsCouples)
     })
 
     test('initTabs', () => {
@@ -37,7 +37,7 @@ describe("tabs", () => {
         expect(allTabs[tabStub.id]).toStrictEqual(tabStub);
     });
 
-    test('tab onUpdated - with status "complete" it calls refreshCouplesForTabAndItsCouples', () => {
+    test('tab onUpdated - with status "complete" it calls removeCouplesForTabAndItsCouples', () => {
         let tabStub = {id: 1};
 
         initTabs(chrome)
@@ -45,11 +45,11 @@ describe("tabs", () => {
         // noinspection JSUnresolvedFunction
         chrome.tabs.onUpdated.dispatch(1, {status: "complete"}, tabStub)
 
-        expect(refreshCouplesForTabAndItsCouples.calledOnce).toBeTruthy()
-        expect(refreshCouplesForTabAndItsCouples.args[0][0]).toEqual(tabStub)
+        expect(removeCouplesForTabAndItsCouples.calledOnce).toBeTruthy()
+        expect(removeCouplesForTabAndItsCouples.args[0][0]).toEqual(tabStub)
     });
 
-    test('tab onActivated - resolves tab, adds it and calls refreshCouplesForTabAndItsCouples', () => {
+    test('tab onActivated - resolves tab, adds it and calls removeCouplesForTabAndItsCouples', () => {
         let tabActiveInfo = {tabId: 1}
 
         initTabs(chrome)
@@ -65,8 +65,8 @@ describe("tabs", () => {
         chrome.tabs.get.args[0][1](tabStub)
 
         expect(allTabs[tabStub.id]).toStrictEqual(tabStub);
-        expect(refreshCouplesForTabAndItsCouples.calledOnce).toBeTruthy()
-        expect(refreshCouplesForTabAndItsCouples.args[0][0]).toEqual(tabStub)
+        expect(removeCouplesForTabAndItsCouples.calledOnce).toBeTruthy()
+        expect(removeCouplesForTabAndItsCouples.args[0][0]).toEqual(tabStub)
     })
 
     test('tab onCreated - adds tab', () => {

--- a/background/tabs.test.js
+++ b/background/tabs.test.js
@@ -7,6 +7,7 @@ let allTabs = null;
 let coupleTabsWithGroups = null;
 let loadConfigurationAsObject = null;
 let decoupleTabFromGroups = null;
+let sync = null;
 
 describe("tabs", () => {
     beforeEach(() => {
@@ -20,6 +21,8 @@ describe("tabs", () => {
         moduleUnderTest.__set__('loadConfigurationAsObject', loadConfigurationAsObject);
         decoupleTabFromGroups = sinon.spy();
         moduleUnderTest.__set__('decoupleTabFromGroups', decoupleTabFromGroups);
+        sync = sinon.spy();
+        moduleUnderTest.__set__('sync', sync);
         initTabs(chrome)
     })
 
@@ -37,9 +40,7 @@ describe("tabs", () => {
 
         expect(allTabs[tabStub.id]).toStrictEqual(tabStub);
 
-        expect(coupleTabsWithGroups.calledOnce).toBeTruthy()
-        expect(coupleTabsWithGroups.args[0][0]).toEqual(allTabs)
-        expect(coupleTabsWithGroups.args[0][1]).toEqual(loadConfigurationAsObject)
+        expect(sync.calledOnce).toBeTruthy();
     });
 
 
@@ -56,6 +57,7 @@ describe("tabs", () => {
         chrome.tabs.get.args[0][1](tabStub)
 
         expect(allTabs[tabStub.id]).toStrictEqual(tabStub);
+        expect(sync.calledOnce).toBeTruthy();
     })
 
     test('tab onCreated - adds tab', () => {
@@ -64,6 +66,7 @@ describe("tabs", () => {
         chrome.tabs.onCreated.dispatch(tabStub)
 
         expect(allTabs[tabStub.id]).toStrictEqual(tabStub);
+        expect(sync.calledOnce).toBeTruthy();
     })
 
     test('tab onRemoved - removes tab', () => {

--- a/content/eventDispatching.js
+++ b/content/eventDispatching.js
@@ -1,12 +1,14 @@
 const debugEvents = false;
 const debugElementPathIssues = false;
 
-function receiveEventBroadcastFromBackgroundScript(request, sender, sendResponse) {
+function receiveEventBroadcastFromBackgroundScript(request) {
     if (debugEvents === true && request.event === "change") {
         console.log(request)
     }
 
-    if (request.elementPath !== "") {
+    if (request.type === "COUPLING_STATUS_CHANGE") {
+        handleCouplingStatusChange(request);
+    } else if (request.elementPath !== "") {
         const element = DomUtil.findElementByPath(request.elementPath);
         if (element === null) {
             if (debugElementPathIssues) {
@@ -16,13 +18,13 @@ function receiveEventBroadcastFromBackgroundScript(request, sender, sendResponse
         }
         dispatchDomElementEvent(request, element);
     } else {
-        dispatchNonDomElementEvent(request, sendResponse);
+        dispatchNonDomElementEvent(request);
     }
 }
 
 chrome.runtime.onMessage.addListener(receiveEventBroadcastFromBackgroundScript);
 
-function dispatchNonDomElementEvent(request, sendResponse) {
+function dispatchNonDomElementEvent(request) {
     switch (request.event) {
         case 'scroll':
             dispatchScrollEvent(window, request);

--- a/content/ui.js
+++ b/content/ui.js
@@ -1,11 +1,10 @@
 function handleCouplingStatusChange(request) {
-    console.log(request.value, request.groupName)
     let elem = document.createElement('div');
     elem.id = "mirror-extension-couplingIndicator"
     const css = 'position:fixed;box-sizing: border-box;top:0;right:0;width:40px;height:40px;opacity:0.3;z-index:100;background-color:#00ff00;';
     const existingElem = document.getElementById(elem.id);
 
-    if (typeof existingElem !== "undefined" && existingElem !== null) {
+    if (existingElem !== null) {
         elem = existingElem
     } else {
         document.body.appendChild(elem);

--- a/content/ui.js
+++ b/content/ui.js
@@ -1,7 +1,9 @@
 function handleCouplingStatusChange(request) {
     let elem = document.createElement('div');
     elem.id = "mirror-extension-couplingIndicator"
-    const css = 'position:fixed;box-sizing: border-box;top:0;right:0;width:40px;height:40px;opacity:0.3;z-index:100;background-color:#00ff00;';
+    elem.innerHTML = "M"
+    elem.title = "This tab is mirrored by Mirror Extension"
+    const css = getIndicatorCss();
     const existingElem = document.getElementById(elem.id);
 
     if (existingElem !== null) {
@@ -19,4 +21,25 @@ function handleCouplingStatusChange(request) {
     if (request.value === "DECOUPLED") {
         elem.style.cssText = css + "display:none";
     }
+}
+
+function getIndicatorCss() {
+    return `
+    position:fixed;
+    display:flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    top:0;
+    right:0;
+    width:40px;
+    height:40px;
+    opacity:0.3;
+    z-index:100;
+    background-color:rgba(144, 199 ,255, 0.67);
+    font-size: 30px;
+    font-weight: bold;
+    font-family:monospace;
+    color:black;
+    `.replaceAll('\n', '');
 }

--- a/content/ui.js
+++ b/content/ui.js
@@ -1,0 +1,23 @@
+function handleCouplingStatusChange(request) {
+    console.log(request.value, request.groupName)
+    let elem = document.createElement('div');
+    elem.id = "mirror-extension-couplingIndicator"
+    const css = 'position:fixed;box-sizing: border-box;top:0;right:0;width:40px;height:40px;opacity:0.3;z-index:100;background-color:#00ff00;';
+    const existingElem = document.getElementById(elem.id);
+
+    if (typeof existingElem !== "undefined" && existingElem !== null) {
+        elem = existingElem
+    } else {
+        document.body.appendChild(elem);
+    }
+
+    elem.style.cssText = css;
+
+    if (request.value === "COUPLED") {
+        elem.style.cssText = css;
+    }
+
+    if (request.value === "DECOUPLED") {
+        elem.style.cssText = css + "display:none";
+    }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    roots: ['<rootDir>'],
+    testRegex: '(/__tests__/.*|(\\.|/)(test))\\.js?$',
+    "collectCoverageFrom": [
+        "(background|content)/*.js"
+    ],
+}

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
       "background/tabs.js",
       "background/eventBroadcasting.js",
       "background/tabCoupling.js",
-      "background/configuration.js"
+      "background/configuration.js",
+      "background/init.js"
     ],
     "persistent": false
   },

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,7 @@
   ],
   "background": {
     "scripts": [
+      "background/tabs.js",
       "background/eventBroadcasting.js",
       "background/tabCoupling.js",
       "background/configuration.js"

--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,8 @@
       "js": [
         "content/dom.js",
         "content/eventCapturing.js",
-        "content/eventDispatching.js"
+        "content/eventDispatching.js",
+        "content/ui.js"
       ],
       "run_at": "document_end",
       "all_frames": true

--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
   "author": "Oppodelldog <odog@netcologne.de>",
   "license": "MIT",
   "devDependencies": {
+    "@jest/globals": "^26.5.3",
     "jest": "^26.0.1",
-    "rewire": "^5.0.0",
-    "@jest/globals": "^26.5.3"
+    "rewire": "^5.0.0"
+  },
+  "dependencies": {
+    "sinon": "^9.2.0",
+    "sinon-chrome": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
   "devDependencies": {
     "@jest/globals": "^26.5.3",
     "jest": "^26.0.1",
-    "rewire": "^5.0.0"
-  },
-  "dependencies": {
+    "rewire": "^5.0.0",
     "sinon": "^9.2.0",
     "sinon-chrome": "^3.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -5,5 +5,10 @@
   "main": "popup/index.html",
   "repository": "https://github.com/Oppodelldog/chrome-extension-mirror.git",
   "author": "Oppodelldog <odog@netcologne.de>",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "jest": "^26.0.1",
+    "rewire": "^5.0.0",
+    "@jest/globals": "^26.5.3"
+  }
 }

--- a/popup/configurationController.js
+++ b/popup/configurationController.js
@@ -30,12 +30,14 @@ const controller = angular.module('app').controller("ConfigurationController", f
     }
 
     this.saveConfiguration = function () {
-        chrome.extension.getBackgroundPage().saveConfiguration(angular.toJson(vm.configuration));
+        let backgroundPage = chrome.extension.getBackgroundPage();
+        backgroundPage.saveConfiguration(angular.toJson(vm.configuration));
+        backgroundPage.sync();
     }
 
     this.loadConfiguration();
 });
 
-document.addEventListener("unload", function(e){
-	alert("CLOSED");
+document.addEventListener("unload", function (e) {
+    alert("CLOSED");
 }, true);

--- a/popup/overviewController.js
+++ b/popup/overviewController.js
@@ -10,14 +10,14 @@ angular.module('app').controller("OverviewController", function ($scope) {
 
 function loadMirroredTabs(successFunc) {
 
-    const tabCouples = chrome.extension.getBackgroundPage().tabCouples;
+    const couplings = [];
 
     chrome.tabs.getSelected(null, function (currentTab) {
         chrome.tabs.query({}, function (allTabs) {
             const tabInfo = getTabInfoFromTabs(allTabs);
             const mirroredTabs = [];
-            for (let tabId in tabCouples) {
-                if (!tabCouples.hasOwnProperty(tabId)) {
+            for (let k in couplings) {
+                if (!couplings.hasOwnProperty(k)) {
                     continue;
                 }
 
@@ -25,12 +25,12 @@ function loadMirroredTabs(successFunc) {
                     continue;
                 }
 
-                for (let e in tabCouples[tabId]) {
-                    if (!tabCouples[tabId].hasOwnProperty(e)) {
+                for (let e in couplings[tabId]) {
+                    if (!couplings[tabId].hasOwnProperty(e)) {
                         continue;
                     }
 
-                    const coupledTabId = tabCouples[tabId][e];
+                    const coupledTabId = couplings[tabId][e];
                     mirroredTabs[coupledTabId] = tabInfo[coupledTabId];
                 }
             }


### PR DESCRIPTION
Adding a simple UI element to the right top of each connected tab.
Rewrote coupling logic that holds now configured mirror groups along with a list of connected tabs.
Couplings are re-evaluated when
* new tab  is created
* tab is status "complete"
* tab is removed
* configuration is saved

This now gives immediate feedback.

this solves #5 


